### PR TITLE
Refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures 0.2.11",
+ "cpufeatures 0.2.12",
  "ctr 0.8.0",
  "opaque-debug",
 ]
@@ -55,9 +55,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.6"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -82,13 +82,12 @@ checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "alloy-rlp"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc0fac0fc16baf1f63f78b47c3d24718f3619b0714076f6a02957d808d52cbef"
+checksum = "8d58d9f5da7b40e9bfff0b7e7816700be4019db97d4b6359fe7f94a9e22e42ac"
 dependencies = [
  "arrayvec",
  "bytes",
- "smol_str",
 ]
 
 [[package]]
@@ -108,9 +107,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.5"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d664a92ecae85fd0a7392615844904654d1d5f5514837f471ddef4a057aba1b6"
+checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -122,9 +121,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.4"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
 
 [[package]]
 name = "anstyle-parse"
@@ -156,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.75"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
 
 [[package]]
 name = "arc-swap"
@@ -307,25 +306,24 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.75"
+version = "0.1.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdf6721fb0140e4f897002dd086c06f6c27775df19cfe1fccb21181a48fd2c98"
+checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "auto_impl"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fee3da8ef1276b0bee5dd1c7258010d8fffd31801447323115a25560e1327b89"
+checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
 dependencies = [
- "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -397,7 +395,7 @@ version = "0.66.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "cexpr",
  "clang-sys",
  "lazy_static",
@@ -410,7 +408,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.48",
+ "syn 2.0.52",
  "which",
 ]
 
@@ -422,9 +420,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 dependencies = [
  "serde",
 ]
@@ -481,9 +479,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.14.0"
+version = "3.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
 
 [[package]]
 name = "byte-slice-cast"
@@ -522,10 +520,9 @@ dependencies = [
 
 [[package]]
 name = "c-kzg"
-version = "0.1.0"
-source = "git+https://github.com/ethereum/c-kzg-4844#e266280d88f006b23925c5062476b316d5407cb1"
+version = "0.4.3"
+source = "git+https://github.com/ethereum/c-kzg-4844#fb1bc6217c3ceb09d93445cd1d4681f094079e54"
 dependencies = [
- "bindgen",
  "blst",
  "cc",
  "glob",
@@ -535,9 +532,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
 dependencies = [
  "jobserver",
  "libc",
@@ -560,9 +557,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.31"
+version = "0.4.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
+checksum = "8eaf5903dcbc0a39312feb77df2ff4c76387d591b9fc7b04a238dcf8bb62639a"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -570,7 +567,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -584,9 +581,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c688fc74432808e3eb684cae8830a86be1d66a2bd58e1f248ed0960a590baf6f"
+checksum = "67523a3b4be3ce1989d607a828d036249522dd9c1c8de7f4dd2dae43a37369d1"
 dependencies = [
  "glob",
  "libc",
@@ -595,9 +592,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.11"
+version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfaff671f6b22ca62406885ece523383b9b64022e341e53e009a62ebc47a45f2"
+checksum = "b230ab84b0ffdf890d5a10abdbc8b83ae1c4918275daea1ab8801f71536b2651"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -605,33 +602,33 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.11"
+version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a216b506622bb1d316cd51328dce24e07bdff4a6128a47c7e7fad11878d5adbb"
+checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
 dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
+ "strsim 0.11.0",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.4.7"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
+checksum = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "codecs-derive"
@@ -643,7 +640,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -656,7 +653,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -667,12 +664,12 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "const-hex"
-version = "1.10.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5104de16b218eddf8e34ffe2f86f74bfa4e61e95a1b89732fccf6325efd0557"
+checksum = "efbd12d49ab0eaf8193ba9175e45f56bbc2e4b27d57b8cfe62aa47942a46b9a9"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.11",
+ "cpufeatures 0.2.12",
  "hex",
  "proptest",
  "serde",
@@ -732,9 +729,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0"
+checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
 dependencies = [
  "libc",
 ]
@@ -756,44 +753,37 @@ checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc32fast"
-version = "1.3.2"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fca89a0e215bab21874660c67903c5f143333cab1da83d041c7ded6053774751"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
 dependencies = [
- "cfg-if",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.16"
+version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2fe95351b870527a5d09bf563ed3c97c0cffb87cf1c78a591bf48bb218d9aa"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
- "autocfg",
- "cfg-if",
  "crossbeam-utils",
- "memoffset",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.17"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d96137f14f244c37f989d9fff8f95e6c18b918e71f36638f8c49112e4c78f"
-dependencies = [
- "cfg-if",
-]
+checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
 name = "crunchy"
@@ -843,12 +833,12 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.1"
+version = "4.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89b8c6a2e4b1f45971ad09761aafb85514a84744b67a95e32c3cc1352d1f65c"
+checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.11",
+ "cpufeatures 0.2.12",
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
@@ -866,7 +856,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -881,12 +871,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.3"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
+checksum = "54e36fcd13ed84ffdfda6f5be89b31287cbb80c439841fe69e04841435464391"
 dependencies = [
- "darling_core 0.20.3",
- "darling_macro 0.20.3",
+ "darling_core 0.20.8",
+ "darling_macro 0.20.8",
 ]
 
 [[package]]
@@ -899,22 +889,22 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.10.0",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "darling_core"
-version = "0.20.3"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
+checksum = "9c2cf1c23a687a1feeb728783b993c4e1ad83d99f351801977dd809b48d0a70f"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
- "syn 2.0.48",
+ "strsim 0.10.0",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -930,19 +920,19 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.3"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
+checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
- "darling_core 0.20.3",
+ "darling_core 0.20.8",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "decoder"
 version = "0.1.1"
-source = "git+https://github.com/semiotic-ai/flat-files-decoder.git?branch=main#b9bc52c3ee637b227e50311827a91f8d5e17e26d"
+source = "git+https://github.com/semiotic-ai/flat-files-decoder.git?branch=main#cc68ee059b02d0a23f52908e76ef147b9d4c7fe6"
 dependencies = [
  "anyhow",
  "bincode",
@@ -951,9 +941,7 @@ dependencies = [
  "prost",
  "prost-build",
  "prost-types",
- "prost-wkt",
  "prost-wkt-build",
- "prost-wkt-types",
  "rand",
  "rayon",
  "reth-primitives 0.1.0-alpha.4",
@@ -961,6 +949,7 @@ dependencies = [
  "revm-primitives 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "serde_json",
+ "sf-protos",
  "simple-log",
  "thiserror",
  "tokio",
@@ -989,9 +978,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eb30d70a07a3b04884d2677f06bec33509dc67ca60d92949e5535352d3191dc"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
  "serde",
@@ -1044,9 +1033,9 @@ dependencies = [
 
 [[package]]
 name = "discv5"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63b0b31b65aa1fcbd4e0171f1afed5363ccf25efb988ecd42450036f4c6d8539"
+checksum = "bac33cb3f99889a57e56a8c6ccb77aaf0cfc7787602b7af09783f736d77314e1"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1068,7 +1057,6 @@ dependencies = [
  "socket2 0.4.10",
  "tokio",
  "tracing",
- "tracing-subscriber",
  "uint",
  "zeroize",
 ]
@@ -1099,9 +1087,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f628eaec48bfd21b865dc2950cfa014450c01d2fa2b69a86c2fd5844ec523c0"
+checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
@@ -1114,9 +1102,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 
 [[package]]
 name = "elliptic-curve"
@@ -1158,13 +1146,13 @@ dependencies = [
 
 [[package]]
 name = "enumn"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ad8cef1d801a4686bfd8919f0b30eac4c8e48968c437a6405ded4fb5272d2b"
+checksum = "6fd000fd6988e73bbe993ea3db9b1aa64906ab88766d654973924340c8cddb42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1179,9 +1167,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95b3f3e67048839cb0d0781f445682a35113da7121f7c949db0e2be96a4fbece"
+checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
 dependencies = [
  "humantime 2.1.0",
  "is-terminal",
@@ -1198,9 +1186,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "erased-serde"
-version = "0.4.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4adbf0983fe06bd3a5c19c8477a637c2389feb0994eca7a59e3b961054aa7c0a"
+checksum = "388979d208a049ffdfb22fa33b9c81942215b940910bccfe258caeb25d125cb3"
 dependencies = [
  "serde",
 ]
@@ -1230,8 +1218,7 @@ dependencies = [
 [[package]]
 name = "eth_trie"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3aeb0284b473041df2419a28e3cdf0c64a78d2b9511af4b6e40bad3964b172"
+source = "git+https://github.com/morph-dev/eth-trie.rs.git?branch=trin#83bf198df680cde7abea9de049f4b78ab9c81309"
 dependencies = [
  "ethereum-types",
  "hashbrown 0.14.3",
@@ -1295,7 +1282,7 @@ version = "1.0.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233dc6f434ce680dbabf4451ee3380cec46cb3c45d66660445a435619710dd35"
 dependencies = [
- "cpufeatures 0.2.11",
+ "cpufeatures 0.2.12",
  "lazy_static",
  "ring 0.16.20",
  "sha2 0.10.8",
@@ -1303,9 +1290,9 @@ dependencies = [
 
 [[package]]
 name = "ethereum_serde_utils"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f8cb04ea380a33e9c269fa5f8df6f2d63dee19728235f3e639e7674e038686a"
+checksum = "de4d5951468846963c24e8744c133d44f39dff2cd3a233f6be22b370d08a524f"
 dependencies = [
  "ethereum-types",
  "hex",
@@ -1339,9 +1326,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-core"
-version = "2.0.11"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f03e0bdc216eeb9e355b90cf610ef6c5bb8aca631f97b5ae9980ce34ea7878d"
+checksum = "82d80cc6ad30b14a48ab786523af33b37f28a8623fc06afd55324816ef18fb1f"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -1357,7 +1344,7 @@ dependencies = [
  "rlp",
  "serde",
  "serde_json",
- "strum 0.25.0",
+ "strum 0.26.1",
  "tempfile",
  "thiserror",
  "tiny-keccak",
@@ -1373,7 +1360,7 @@ checksum = "b90ca2580b73ab6a1f724b76ca11ab632df820fd6040c336200d2c1df7b3c82c"
 [[package]]
 name = "ethportal-api"
 version = "0.2.2"
-source = "git+https://github.com/ethereum/trin.git#4645fef9979d358f3c73a440147c8f076fb7aebe"
+source = "git+https://github.com/ethereum/trin.git#70d68fa8654d64128d29f2fbbe6b77d99c099b7c"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
@@ -1400,7 +1387,7 @@ dependencies = [
  "serde",
  "serde-this-or-that",
  "serde_json",
- "serde_yaml 0.9.28",
+ "serde_yaml 0.9.32",
  "sha2 0.10.8",
  "sha3 0.9.1",
  "snap",
@@ -1450,9 +1437,9 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27573eac26f4dd11e2b1916c3fe1baa56407c83c71a773a8ba17ec0bca03b6b7"
+checksum = "1676f435fc1dadde4d03e43f5d62b259e1ce5f40bd4ffb21db2b42ebe59c1382"
 
 [[package]]
 name = "fixed-hash"
@@ -1505,9 +1492,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0290714b38af9b4a7b094b8a37086d1b4e61f2df9122c3cad2577669145335"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1520,9 +1507,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff4dd66668b557604244583e3e1e1eada8c5c2e96a6d0d6653ede395b78bbacb"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1530,15 +1517,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f4fb8693db0cf099eadcca0efe2a5a22e4550f98ed16aba6c48700da29597bc"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1547,38 +1534,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf34a163b5c4c52d0478a4d757da8fb65cabef42ba90515efee0f6f9fa45aaa"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e36d3378ee38c2a36ad710c5d30c2911d752cb941c00c72dbabfb786a7970817"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
 
 [[package]]
 name = "futures-task"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd193069b0ddadc69c46389b740bbccdd97203899b48d09c5f7969591d6bae2"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
 name = "futures-timer"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 dependencies = [
  "gloo-timers",
  "send_wrapper",
@@ -1586,9 +1573,9 @@ dependencies = [
 
 [[package]]
 name = "futures-util"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19526d624e703a3179b3d322efec918b6246ea0fa51d41124525f00f1cc8104"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1615,9 +1602,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
+checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1705,9 +1692,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.22"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d6250322ef6e60f93f9a2162799302cd6f68f79f6e5d85c8c16f14d1d958178"
+checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
 dependencies = [
  "bytes",
  "fnv",
@@ -1715,7 +1702,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 2.1.0",
+ "indexmap 2.2.5",
  "slab",
  "tokio",
  "tokio-util",
@@ -1772,17 +1759,20 @@ dependencies = [
  "bincode",
  "clap",
  "decoder",
- "env_logger 0.10.1",
+ "env_logger 0.10.2",
  "ethereum-types",
  "ethportal-api",
  "log",
  "primitive-types",
+ "prost-build",
+ "prost-wkt-build",
  "protobuf",
  "protobuf-json-mapping",
  "revm-primitives 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rlp",
  "serde",
  "serde_json",
+ "sf-protos",
  "tempfile",
  "tree_hash",
  "trin-validation",
@@ -1796,9 +1786,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.3"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hex"
@@ -1850,9 +1840,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
 dependencies = [
  "bytes",
  "fnv",
@@ -1914,7 +1904,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.5",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -1931,7 +1921,7 @@ dependencies = [
  "http",
  "hyper",
  "log",
- "rustls",
+ "rustls 0.21.10",
  "rustls-native-certs",
  "tokio",
  "tokio-rustls",
@@ -1939,9 +1929,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.58"
+version = "0.1.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8326b86b6cff230b97d0d312a6c40a60726df3332e721f72a1b035f451663b20"
+checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -2044,9 +2034,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.1.0"
+version = "2.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
+checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
@@ -2064,19 +2054,19 @@ dependencies = [
 
 [[package]]
 name = "inventory"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8573b2b1fb643a372c73b23f4da5f888677feef3305146d68a539250a9bccc7"
+checksum = "f958d3d68f4167080a18141e10381e7634563984a537f2a49a30fd8e53ac5767"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.9"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
+checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
 dependencies = [
  "hermit-abi",
- "rustix",
- "windows-sys 0.48.0",
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2111,18 +2101,18 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "jobserver"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
+checksum = "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.66"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cee9c64da59eae3b50095c18d3e74f8b73c0b86d2792824ff01bbce68ba229ca"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2165,7 +2155,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "url",
- "webpki-roots",
+ "webpki-roots 0.25.4",
 ]
 
 [[package]]
@@ -2290,9 +2280,9 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f01b677d82ef7a676aa37e099defd83a28e15687112cafdd112d60236b6115b"
+checksum = "956ff9b67e26e1a6a866cb758f12c6f8746208489e3e4a4b5580802f2f0a587b"
 dependencies = [
  "cfg-if",
  "ecdsa",
@@ -2304,11 +2294,11 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f6d5ed8676d904364de097082f4e7d240b571b67989ced0240f08b7f966f940"
+checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
 dependencies = [
- "cpufeatures 0.2.11",
+ "cpufeatures 0.2.12",
 ]
 
 [[package]]
@@ -2335,18 +2325,18 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.151"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libloading"
-version = "0.7.4"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
+checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if",
- "winapi",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -2363,9 +2353,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
+checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "lock_api"
@@ -2379,9 +2369,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 dependencies = [
  "serde",
 ]
@@ -2418,20 +2408,11 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2994eeba8ed550fd9b47a0b38f0242bc3344e496483c6180b69139cc2fa5d1d7"
+checksum = "d3262e75e648fce39813cb56ac41f3c3e3f65217ebf3844d818d1f9398cfb0dc"
 dependencies = [
  "hashbrown 0.14.3",
-]
-
-[[package]]
-name = "matchers"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
-dependencies = [
- "regex-automata 0.1.10",
 ]
 
 [[package]]
@@ -2442,18 +2423,9 @@ checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "memchr"
-version = "2.6.4"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
-
-[[package]]
-name = "memoffset"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
-dependencies = [
- "autocfg",
-]
+checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "minimal-lexical"
@@ -2463,18 +2435,18 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
 dependencies = [
  "adler",
 ]
 
 [[package]]
 name = "mio"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "wasi",
@@ -2531,16 +2503,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nu-ansi-term"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
-dependencies = [
- "overload",
- "winapi",
-]
-
-[[package]]
 name = "num-bigint"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2552,20 +2514,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-integer"
-version = "0.1.45"
+name = "num-conv"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "autocfg",
  "num-traits",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
  "autocfg",
  "libm",
@@ -2583,30 +2550,30 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683751d591e6d81200c39fb0d1032608b77724f34114db54f571ff1317b337c0"
+checksum = "02339744ee7253741199f897151b38e72257d13802d4ee837285cc2990a90845"
 dependencies = [
  "num_enum_derive",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c11e44798ad209ccdd91fc192f0526a369a01234f7373e1b141c96d7cee4f0e"
+checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
 dependencies = [
- "proc-macro-crate 2.0.1",
+ "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "object"
-version = "0.32.1"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
+checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
 dependencies = [
  "memchr",
 ]
@@ -2619,9 +2586,9 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "opaque-debug"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "open-fastrlp"
@@ -2664,12 +2631,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
-
-[[package]]
 name = "parity-scale-codec"
 version = "3.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2690,7 +2651,7 @@ version = "3.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be30eaf4b0a9fba5336683b38de57bb86d179a35862ba6bfcf57625d006bde5b"
 dependencies = [
- "proc-macro-crate 2.0.1",
+ "proc-macro-crate 2.0.0",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -2764,9 +2725,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.5"
+version = "2.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae9cee2a55a544be8b89dc6848072af97a20f2422603c10865be2a42b580fff5"
+checksum = "56f8023d0fb78c8e03784ea1c7f3fa36e68a723138990b8d5a47d916b651e7a8"
 dependencies = [
  "memchr",
  "thiserror",
@@ -2780,27 +2741,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.1.0",
+ "indexmap 2.2.5",
 ]
 
 [[package]]
 name = "pin-project"
-version = "1.1.3"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fda4ed1c6c173e3fc7a83629421152e01d7b1f9b7f65fb301e490e8cfc656422"
+checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.3"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
+checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2827,9 +2788,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d3587f8a9e599cc7ec2c00e331f71c4e69a5f9a4b8a6efd5b07466b9736f9a"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "plain_hasher"
@@ -2842,9 +2803,9 @@ dependencies = [
 
 [[package]]
 name = "platforms"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14e6ab3f592e6fb464fc9712d8d6e6912de6473954635fd76a589d832cffcbb0"
+checksum = "626dec3cac7cc0e1577a2ec3fc496277ec2baa084bebad95bb6fdbfae235f84c"
 
 [[package]]
 name = "polyval"
@@ -2853,7 +2814,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8419d2b623c7c0896ff2d5d96e2cb4ede590fed28fcc34934f4c33c036e620a1"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.11",
+ "cpufeatures 0.2.12",
  "opaque-debug",
  "universal-hash",
 ]
@@ -2872,12 +2833,12 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
+checksum = "a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5"
 dependencies = [
  "proc-macro2",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2906,12 +2867,20 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "2.0.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97dc5fea232fc28d2f597b37c4876b348a40e33f3b02cc975c8d006d78d94b1a"
+checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
 dependencies = [
- "toml_datetime",
- "toml_edit 0.20.2",
+ "toml_edit 0.20.7",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
+dependencies = [
+ "toml_edit 0.21.1",
 ]
 
 [[package]]
@@ -2953,13 +2922,13 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b476131c3c86cb68032fdc5cb6d5a1045e3e42d96b69fa599fd77701e1f5bf"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "lazy_static",
  "num-traits",
  "rand",
  "rand_chacha",
  "rand_xorshift",
- "regex-syntax 0.8.2",
+ "regex-syntax",
  "unarray",
 ]
 
@@ -2981,7 +2950,7 @@ checksum = "c55e02e35260070b6f716a2423c2ff1c3bb1642ddca6f99e1f26d06268a0e2d2"
 dependencies = [
  "bytes",
  "heck",
- "itertools 0.11.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "once_cell",
@@ -2990,7 +2959,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.48",
+ "syn 2.0.52",
  "tempfile",
  "which",
 ]
@@ -3002,10 +2971,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efb6c9a1dd1def8e2124d17e83a20af56f1570d6c2d2bd9e266ccb768df3840e"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -3167,9 +3136,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
+checksum = "e4963ed1bc86e4f3ee217022bd855b297cef07fb9eac5dfa1f788b220b49b3bd"
 dependencies = [
  "either",
  "rayon-core",
@@ -3177,9 +3146,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -3211,41 +3180,26 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.2"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.3",
- "regex-syntax 0.8.2",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.1.10"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.2",
+ "regex-syntax",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -3319,7 +3273,7 @@ version = "0.1.0-alpha.10"
 source = "git+https://github.com/paradigmxyz/reth.git?tag=v0.1.0-alpha.10#1b16d804ef01f4ec3c25e7986381c22739c105b9"
 dependencies = [
  "bytes",
- "c-kzg 0.1.0 (git+https://github.com/ethereum/c-kzg-4844?rev=f5f6f863d475847876a2bd5ee252058d37c3a15d)",
+ "c-kzg 0.1.0",
  "crc",
  "crunchy",
  "derive_more",
@@ -3341,7 +3295,7 @@ dependencies = [
  "secp256k1",
  "serde",
  "serde_json",
- "serde_with 3.4.0",
+ "serde_with 3.6.1",
  "sha2 0.10.8",
  "strum 0.25.0",
  "sucds 0.6.0",
@@ -3376,7 +3330,7 @@ dependencies = [
  "arrayvec",
  "auto_impl",
  "bytes",
- "c-kzg 0.1.0 (git+https://github.com/ethereum/c-kzg-4844?rev=f5f6f863d475847876a2bd5ee252058d37c3a15d)",
+ "c-kzg 0.1.0",
  "ethereum-types",
  "reth-rlp-derive 0.1.0-alpha.10",
  "revm-primitives 1.1.2 (git+https://github.com/bluealloy/revm?rev=516f62cc)",
@@ -3389,7 +3343,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v0.1.0-alpha.4#b2b2cbedb52
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -3399,7 +3353,7 @@ source = "git+https://github.com/paradigmxyz/reth.git?tag=v0.1.0-alpha.10#1b16d8
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -3444,10 +3398,10 @@ version = "1.1.2"
 source = "git+https://github.com/bluealloy/revm?rev=516f62cc#516f62ccc1c5f2a62e5fc58115213fe04c7f7a8c"
 dependencies = [
  "auto_impl",
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "bitvec",
  "bytes",
- "c-kzg 0.1.0 (git+https://github.com/ethereum/c-kzg-4844)",
+ "c-kzg 0.4.3",
  "derive_more",
  "enumn",
  "fixed-hash",
@@ -3489,16 +3443,17 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.7"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "688c63d65483050968b2a8937f7995f443e27041a0f7700aa59b0822aedebb74"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
+ "cfg-if",
  "getrandom",
  "libc",
  "spin 0.9.8",
  "untrusted 0.9.0",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3531,9 +3486,9 @@ checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 
 [[package]]
 name = "ruint"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608a5726529f2f0ef81b8fde9873c4bb829d6b5b5ca6be4d97345ddf0749c825"
+checksum = "49b1d9521f889713d1221270fdd63370feca7e5c71a18745343402fa86e4f04f"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",
@@ -3555,9 +3510,9 @@ dependencies = [
 
 [[package]]
 name = "ruint-macro"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e666a5496a0b2186dbcd0ff6106e29e093c15591bde62c20d3842007c6978a09"
+checksum = "f86854cf50259291520509879a5c294c3c9a4c334e9ff65071c51e42ef1e2343"
 
 [[package]]
 name = "rust-embed"
@@ -3579,7 +3534,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.48",
+ "syn 2.0.52",
  "walkdir",
 ]
 
@@ -3626,16 +3581,16 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.20",
+ "semver 1.0.22",
 ]
 
 [[package]]
 name = "rustix"
-version = "0.38.28"
+version = "0.38.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72e572a5e8ca657d7366229cdde4bd14c4eb5499a9573d4d366fe1b599daa316"
+checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3649,9 +3604,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
 dependencies = [
  "log",
- "ring 0.17.7",
- "rustls-webpki",
+ "ring 0.17.8",
+ "rustls-webpki 0.101.7",
  "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e87c9956bd9807afa1f77e0f7594af32566e830e088a5576d27c5b6f30f49d41"
+dependencies = [
+ "log",
+ "ring 0.17.8",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.2",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -3676,12 +3645,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pki-types"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ede67b28608b4c60685c7d54122d4400d90f62b40caee7700e700380a390fa8"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring 0.17.7",
+ "ring 0.17.8",
+ "untrusted 0.9.0",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faaa0a62740bedb9b2ef5afa303da42764c012f743917351dc9a237ea1663610"
+dependencies = [
+ "ring 0.17.8",
+ "rustls-pki-types",
  "untrusted 0.9.0",
 ]
 
@@ -3693,9 +3679,9 @@ checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "ryu"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
+checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
 name = "same-file"
@@ -3732,11 +3718,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
+checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3751,7 +3737,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring 0.17.7",
+ "ring 0.17.8",
  "untrusted 0.9.0",
 ]
 
@@ -3822,9 +3808,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.20"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
+checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 
 [[package]]
 name = "semver-parser"
@@ -3843,9 +3829,9 @@ checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
 
 [[package]]
 name = "serde"
-version = "1.0.196"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
 ]
@@ -3871,20 +3857,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.196"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.108"
+version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
+checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
 dependencies = [
  "itoa",
  "ryu",
@@ -3909,18 +3895,19 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.4.0"
+version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64cd236ccc1b7a29e7e2739f27c0b2dd199804abc4290e32f59f3b68d6405c23"
+checksum = "15d167997bd841ec232f5b2b8e0e26606df2e7caa4c31b95ea9ca52b200bd270"
 dependencies = [
  "base64 0.21.7",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.1.0",
+ "indexmap 2.2.5",
  "serde",
+ "serde_derive",
  "serde_json",
- "serde_with_macros 3.4.0",
+ "serde_with_macros 3.6.1",
  "time",
 ]
 
@@ -3930,22 +3917,22 @@ version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
 dependencies = [
- "darling 0.20.3",
+ "darling 0.20.8",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "serde_with_macros"
-version = "3.4.0"
+version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93634eb5f75a2323b16de4748022ac4297f9e76b6dced2be287a099f41b5e788"
+checksum = "865f9743393e638991566a8b7a479043c2c8da94a33e0a31f18214c9cae0a64d"
 dependencies = [
- "darling 0.20.3",
+ "darling 0.20.8",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -3962,15 +3949,29 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.28"
+version = "0.9.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9269cfafc7e0257ee4a42f3f68a307f458c63d9e7c8ba4b58c5d15f1b7d7e8d3"
+checksum = "8fd075d994154d4a774f95b51fb96bdc2832b0ea48425c92546073816cda1f2f"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap 2.2.5",
  "itoa",
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "sf-protos"
+version = "0.1.0"
+source = "git+https://github.com/semiotic-ai/sf-protos.git?branch=main#d9abf1b30826960efdf02cd63c5c1279c63e6700"
+dependencies = [
+ "prost",
+ "prost-build",
+ "prost-types",
+ "prost-wkt",
+ "prost-wkt-build",
+ "prost-wkt-types",
+ "serde",
 ]
 
 [[package]]
@@ -3981,7 +3982,7 @@ checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if",
- "cpufeatures 0.2.11",
+ "cpufeatures 0.2.12",
  "digest 0.9.0",
  "opaque-debug",
 ]
@@ -3994,7 +3995,7 @@ checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if",
- "cpufeatures 0.2.11",
+ "cpufeatures 0.2.12",
  "digest 0.9.0",
  "opaque-debug",
 ]
@@ -4006,7 +4007,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.11",
+ "cpufeatures 0.2.12",
  "digest 0.10.7",
 ]
 
@@ -4033,19 +4034,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "sharded-slab"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
-dependencies = [
- "lazy_static",
-]
-
-[[package]]
 name = "shlex"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
@@ -4091,18 +4083,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.2"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
-
-[[package]]
-name = "smol_str"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74212e6bbe9a4352329b2f68ba3130c15a3f26fe88ff22dbdc6cdd58fa85e99c"
-dependencies = [
- "serde",
-]
+checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "snap"
@@ -4122,12 +4105,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
+checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4198,6 +4181,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "strsim"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
+
+[[package]]
 name = "strum"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4213,6 +4202,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
 dependencies = [
  "strum_macros 0.25.3",
+]
+
+[[package]]
+name = "strum"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "723b93e8addf9aa965ebe2d11da6d7540fa2283fcea14b3371ff055f7ba13f5f"
+dependencies = [
+ "strum_macros 0.26.1",
 ]
 
 [[package]]
@@ -4238,7 +4236,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.48",
+ "syn 2.0.52",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a3417fc93d76740d974a01654a09777cb500428cc874ca9f45edfe0c4d4cd18"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -4292,9 +4303,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4309,44 +4320,43 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.8.1"
+version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall 0.4.1",
  "rustix",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "termcolor"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff1bc3d3f05aff0403e8ac0d92ced918ec05b666a43f83297ccef5bea8a3d449"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.51"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f11c217e1416d6f036b870f14e0413d480dbf28edbee1f877abaf0206af43bb7"
+checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.51"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01742297787513b79cf8e29d1056ede1313e2420b7b3b15d0a768b4921f549df"
+checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -4361,16 +4371,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thread_local"
-version = "1.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
-dependencies = [
- "cfg-if",
- "once_cell",
-]
-
-[[package]]
 name = "threadpool"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4381,12 +4381,13 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.31"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f657ba42c3f86e7680e53c8cd3af8abbe56b5491790b46e22e19c0d57463583e"
+checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
 dependencies = [
  "deranged",
  "itoa",
+ "num-conv",
  "powerfmt",
  "serde",
  "time-core",
@@ -4401,10 +4402,11 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26197e33420244aeb70c3e8c78376ca46571bc4e701e4791c2cd9f57dcb3a43f"
+checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
 dependencies = [
+ "num-conv",
  "time-core",
 ]
 
@@ -4434,9 +4436,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.35.1"
+version = "1.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89b4efa943be685f629b149f53829423f8f5531ea21249408e8e2f8671ec104"
+checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
 dependencies = [
  "backtrace",
  "bytes",
@@ -4446,7 +4448,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.5",
+ "socket2 0.5.6",
  "tokio-macros",
  "windows-sys 0.48.0",
 ]
@@ -4459,7 +4461,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -4468,7 +4470,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls",
+ "rustls 0.21.10",
  "tokio",
 ]
 
@@ -4501,9 +4503,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
 
 [[package]]
 name = "toml_edit"
@@ -4511,18 +4513,29 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap 2.2.5",
  "toml_datetime",
  "winnow",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.20.2"
+version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
+checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap 2.2.5",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
+dependencies = [
+ "indexmap 2.2.5",
  "toml_datetime",
  "winnow",
 ]
@@ -4574,7 +4587,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -4584,36 +4597,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
- "valuable",
-]
-
-[[package]]
-name = "tracing-log"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.3.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
-dependencies = [
- "matchers",
- "nu-ansi-term",
- "once_cell",
- "regex",
- "sharded-slab",
- "smallvec",
- "thread_local",
- "tracing",
- "tracing-core",
- "tracing-log",
 ]
 
 [[package]]
@@ -4651,10 +4634,9 @@ dependencies = [
 [[package]]
 name = "trin-validation"
 version = "0.1.0"
-source = "git+https://github.com/ethereum/trin.git#4645fef9979d358f3c73a440147c8f076fb7aebe"
+source = "git+https://github.com/ethereum/trin.git#70d68fa8654d64128d29f2fbbe6b77d99c099b7c"
 dependencies = [
  "anyhow",
- "async-trait",
  "eth2_hashing",
  "ethereum-types",
  "ethereum_ssz",
@@ -4684,9 +4666,9 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "typetag"
-version = "0.2.14"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "196976efd4a62737b3a2b662cda76efb448d099b1049613d7a5d72743c611ce0"
+checksum = "661d18414ec032a49ece2d56eee03636e43c4e8d577047ab334c0ba892e29aaf"
 dependencies = [
  "erased-serde",
  "inventory",
@@ -4697,13 +4679,13 @@ dependencies = [
 
 [[package]]
 name = "typetag-impl"
-version = "0.2.14"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eea6765137e2414c44c7b1e07c73965a118a72c46148e1e168b3fc9d3ccf3aa"
+checksum = "ac73887f47b9312552aa90ef477927ff014d63d1920ca8037c6c1951eab64bb1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -4732,9 +4714,9 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f2528f27a9eb2b21e69c95319b30bd0efd85d09c379741b0f78ea1d86be2416"
+checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
 
 [[package]]
 name = "unicode-ident"
@@ -4744,18 +4726,18 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
 dependencies = [
  "tinyvec",
 ]
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-xid"
@@ -4793,20 +4775,21 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "2.9.1"
+version = "2.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cdd25c339e200129fe4de81451814e5228c9b771d57378817d6117cc2b3f97"
+checksum = "11f214ce18d8b2cbe84ed3aa6486ed3f5b285cf8d8fbdbce9f3f767a724adc35"
 dependencies = [
  "base64 0.21.7",
  "flate2",
  "log",
  "once_cell",
- "rustls",
- "rustls-webpki",
+ "rustls 0.22.2",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.2",
  "serde",
  "serde_json",
  "url",
- "webpki-roots",
+ "webpki-roots 0.26.1",
 ]
 
 [[package]]
@@ -4879,9 +4862,9 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "walkdir"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
@@ -4904,9 +4887,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.89"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed0d4f68a3015cc185aff4db9506a015f4b96f95303897bfa23f846db54064e"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -4914,24 +4897,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.89"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b56f625e64f3a1084ded111c4d5f477df9f8c92df113852fa5a374dbda78826"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.39"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac36a15a220124ac510204aec1c3e5db8a22ab06fd6706d881dc6149f8ed9a12"
+checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -4941,9 +4924,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.89"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0162dbf37223cd2afce98f3d0785506dcb8d266223983e4b5b525859e6e182b2"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4951,28 +4934,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.89"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.89"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "web-sys"
-version = "0.3.66"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50c24a44ec86bb68fbecd1b3efed7e85ea5621b39b35ef2766b66cd984f8010f"
+checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4980,9 +4963,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.25.3"
+version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1778a42e8b3b90bff8d0f5032bf22250792889a5cdc752aa0020c84abe3aaf10"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "which"
@@ -5029,11 +5021,11 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
-version = "0.51.1"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.48.5",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -5051,7 +5043,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -5071,17 +5063,17 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.0",
- "windows_aarch64_msvc 0.52.0",
- "windows_i686_gnu 0.52.0",
- "windows_i686_msvc 0.52.0",
- "windows_x86_64_gnu 0.52.0",
- "windows_x86_64_gnullvm 0.52.0",
- "windows_x86_64_msvc 0.52.0",
+ "windows_aarch64_gnullvm 0.52.4",
+ "windows_aarch64_msvc 0.52.4",
+ "windows_i686_gnu 0.52.4",
+ "windows_i686_msvc 0.52.4",
+ "windows_x86_64_gnu 0.52.4",
+ "windows_x86_64_gnullvm 0.52.4",
+ "windows_x86_64_msvc 0.52.4",
 ]
 
 [[package]]
@@ -5092,9 +5084,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -5104,9 +5096,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5116,9 +5108,9 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5128,9 +5120,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5140,9 +5132,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5152,9 +5144,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -5164,15 +5156,15 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
 
 [[package]]
 name = "winnow"
-version = "0.5.30"
+version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b5c3db89721d50d0e2a673f5043fc4722f76dcc352d7b1ab8b8288bed4ed2c5"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
 dependencies = [
  "memchr",
 ]
@@ -5197,22 +5189,22 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.31"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c4061bedbb353041c12f413700357bec76df2c7e2ca8e4df8bac24c6bf68e3d"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.31"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3c129550b3e6de3fd0ba67ba5c81818f9805e58b8d7fee80a3a59d2c9fc601a"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -5232,7 +5224,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-decoder = { git = "https://github.com/semiotic-ai/flat-files-decoder.git", branch = "main" }
 ethportal-api = {git = "https://github.com/ethereum/trin.git", version = "0.2.2"}
 tree_hash = "0.5.2"
 revm-primitives = "=1.1.2"
@@ -23,10 +22,18 @@ protobuf-json-mapping = "3.2.0"
 bincode = "1.3.3"
 serde = "1.0.196"
 base64 = "0.21.7"
+sf-protos = { git = "https://github.com/semiotic-ai/sf-protos.git", branch = "main" }
+
 
 [dev-dependencies]
 tempfile = "3.0"
+decoder = { git = "https://github.com/semiotic-ai/flat-files-decoder.git", branch = "main" }
+
 
 [profile.release]
 codegen-units = 1
 lto = false
+
+[build-dependencies]
+prost-build = "0.12.3"
+prost-wkt-build = "0.5.0"

--- a/Readme.md
+++ b/Readme.md
@@ -26,25 +26,16 @@ against header accumulators. This process is used to verify the authenticity of 
 
 - `-h, --help`: Display a help message that includes usage, commands, and options.
 
-<!-- ## Usage Examples
-
-1.  To validate a stream of epochs, arriving as blocks from flat files:
-
-```
-❯ cargo run era_validate stream 
-```
-
-Then feed the files into the stdin. 
-
-If there are are multiple files to feed, 
-
-
-2. 
- -->
-
-
 
 ## Goals
 
 Our goal is to provide a tool that can be used to verify
 blocks
+
+
+## Testing
+Some tests depend on [flat-files-decoder] to work, so it is used as a development dependency. 
+
+### Coverage
+
+Generate code coverage reports with `cargo llvm-cov --html` and open them with `open ./target/llvm-cov/html/index.html`. 

--- a/Readme.md
+++ b/Readme.md
@@ -1,0 +1,30 @@
+# Header accumulator
+
+This crate is used to accumulate block headers and compare them
+against header accumulators. This process is used to verify the authenticity of these blocks
+
+
+## Getting Started
+
+### Prerequisites
+- [Rust (stable)](https://www.rust-lang.org/tools/install)
+- Cargo (Comes with Rust by default)
+- [protoc](https://grpc.io/docs/protoc-installation/)
+
+## Running
+
+### Commands
+
+
+### Options
+
+
+
+## Usage Examples
+
+
+
+## Goals
+
+Our goal is to provide a tool that can be used to verify
+blocks

--- a/Readme.md
+++ b/Readme.md
@@ -15,12 +15,32 @@ against header accumulators. This process is used to verify the authenticity of 
 
 ### Commands
 
+- `era_validate`: Validates entire ERAs of flat files against Header Accumulators. Use this command to ensure data integrity across different ERAs.
+
+- `generate_inclusion_proof`: Generates inclusion proofs for a range of blocks. This is useful for verifying the presence of specific blocks within a dataset.
+
+- `verify_inclusion_proof`: Verifies inclusion proofs for a range of blocks. Use it to confirm the accuracy of inclusion proofs you have.
+
 
 ### Options
 
+- `-h, --help`: Display a help message that includes usage, commands, and options.
+
+<!-- ## Usage Examples
+
+1.  To validate a stream of epochs, arriving as blocks from flat files:
+
+```
+❯ cargo run era_validate stream 
+```
+
+Then feed the files into the stdin. 
+
+If there are are multiple files to feed, 
 
 
-## Usage Examples
+2. 
+ -->
 
 
 

--- a/Readme.md
+++ b/Readme.md
@@ -1,7 +1,10 @@
 # Header accumulator
 
 This crate is used to accumulate block headers and compare them
-against header accumulators. This process is used to verify the authenticity of these blocks
+against header accumulators. This process is used to verify the authenticity of these blocks.
+
+the header_accumulator is more intended to be used as a library, since it needs to be fed blocks that have to be parsed first.
+
 
 
 ## Getting Started
@@ -11,16 +14,13 @@ against header accumulators. This process is used to verify the authenticity of 
 - Cargo (Comes with Rust by default)
 - [protoc](https://grpc.io/docs/protoc-installation/)
 
-## Running
-
-### Commands
+## Features
 
 - `era_validate`: Validates entire ERAs of flat files against Header Accumulators. Use this command to ensure data integrity across different ERAs.
 
 - `generate_inclusion_proof`: Generates inclusion proofs for a range of blocks. This is useful for verifying the presence of specific blocks within a dataset.
 
 - `verify_inclusion_proof`: Verifies inclusion proofs for a range of blocks. Use it to confirm the accuracy of inclusion proofs you have.
-
 
 ### Options
 
@@ -29,12 +29,17 @@ against header accumulators. This process is used to verify the authenticity of 
 
 ## Goals
 
-Our goal is to provide a tool that can be used to verify
-blocks
+Our goal is to provide a tool that can be used to verify blocks from [StreamingFast's Firehose](https://firehose.streamingfast.io/).
+It is used in unity with flat [flat-files-decoder](https://github.com/semiotic-ai/flat-files-decoder) in [flat_head](https://github.com/semiotic-ai/flat_head) to achieve a solution.
+
+
+
 
 
 ## Testing
-Some tests depend on [flat-files-decoder] to work, so it is used as a development dependency. 
+Some tests depend on [flat-files-decoder](https://github.com/semiotic-ai/flat-files-decoder) to work, so it is used as a development dependency. 
+
+Run `cargo test` to test all functionalities.
 
 ### Coverage
 

--- a/src/era_validator.rs
+++ b/src/era_validator.rs
@@ -52,6 +52,7 @@ pub fn era_validate(
         Some(end_epoch) => end_epoch,
         None => start_epoch + 1,
     };
+
     // Ensure start epoch is less than end epoch
     if start_epoch >= end_epoch {
         Err(EraValidateError::EndEpochLessThanStartEpoch)?;
@@ -59,7 +60,7 @@ pub fn era_validate(
 
     let mut validated_epochs = Vec::new();
     for epoch in start_epoch..=end_epoch {
-        // checkes if epoch was already synced form lockfile.
+        // checks if epoch was already synced form lockfile.
         match check_sync_state(
             Path::new("./lockfile.json"),
             epoch.to_string(),

--- a/src/era_validator.rs
+++ b/src/era_validator.rs
@@ -58,7 +58,7 @@ pub fn era_validate(
     }
 
     let mut validated_epochs = Vec::new();
-    for epoch in start_epoch..end_epoch {
+    for epoch in start_epoch..=end_epoch {
         // checkes if epoch was already synced form lockfile.
         match check_sync_state(
             Path::new("./lockfile.json"),

--- a/src/era_validator.rs
+++ b/src/era_validator.rs
@@ -1,44 +1,39 @@
-use std::{
-    io::{BufRead, Read, Write as StdWrite},
-    path::Path,
-};
-
-use decoder::{
-    headers::HeaderRecordWithNumber,
-    sf::{self, ethereum::r#type::v2::Block},
-};
+use std::path::Path;
 
 use ethportal_api::types::execution::accumulator::HeaderRecord;
-use primitive_types::{H256, U256};
+
 use tree_hash::TreeHash;
 use trin_validation::accumulator::MasterAccumulator;
 
 use crate::{
     errors::EraValidateError,
     sync::{check_sync_state, store_last_state, LockEntry},
-    utils::{
-        compute_epoch_accumulator, decode_header_records, FINAL_EPOCH, MAX_EPOCH_SIZE, MERGE_BLOCK,
-    },
+    types::ExtHeaderRecord,
+    utils::{compute_epoch_accumulator, FINAL_EPOCH, MAX_EPOCH_SIZE, MERGE_BLOCK},
 };
 
-/// Validates many blocks against a header accumulator
+/// Validates many headers against a header accumulator
 ///
 /// It also keeps a record in `lockfile.json` of the validated epochs to skip them
 ///
 /// # Arguments
 ///
-/// * `blocks`-  A mutable vector of blocks. The Vector can be any size, however, it must be in chunks of 8192 blocks
+/// * `headers`-  A mutable vector of [`ExtHeaderRecord`]. The Vector can be any size, however, it must be in chunks of 8192 blocks to work properly
 /// to function without error
-/// * `master_accumulator_file`- An instance of `MasterAccumulator` which is a file that maintains a record of historical epoch
+/// * `master_accumulator_file`- An instance of [`MasterAccumulator`] which is a file that maintains a record of historical epoch
 /// it is used to verify canonical-ness of headers accumulated from the `blocks`
 /// * `start_epoch` -  The epoch number that all the first 8192 blocks are set located
 /// * `end_epoch` -  The epoch number that all the last 8192 blocks are located
+/// * `use_lock` - when set to true, uses the lockfile to store already processed blocks. True by default
 pub fn era_validate(
-    mut blocks: Vec<sf::ethereum::r#type::v2::Block>,
+    mut headers: Vec<ExtHeaderRecord>,
     master_accumulator_file: Option<&String>,
     start_epoch: usize,
     end_epoch: Option<usize>,
+    use_lock: Option<bool>, // Changed to Option<bool>
 ) -> Result<Vec<usize>, EraValidateError> {
+    let use_lock = use_lock.unwrap_or(true);
+
     // Load master accumulator if available, otherwise use default from Portal Network
     let master_accumulator = match master_accumulator_file {
         Some(master_accumulator_file) => {
@@ -61,35 +56,38 @@ pub fn era_validate(
     let mut validated_epochs = Vec::new();
     for epoch in start_epoch..end_epoch {
         // checks if epoch was already synced form lockfile.
-        match check_sync_state(
-            Path::new("./lockfile.json"),
-            epoch.to_string(),
-            master_accumulator.historical_epochs[epoch].0,
-        ) {
-            Ok(true) => {
-                log::info!("Skipping, epoch already synced: {}", epoch);
-                continue;
-            }
-            Ok(false) => {
-                log::info!("syncing new epoch: {}", epoch);
-            }
-            Err(e) => {
-                return {
-                    log::error!("error: {}", e);
-                    Err(EraValidateError::EpochAccumulatorError)
+        if use_lock {
+            match check_sync_state(
+                Path::new("./lockfile.json"),
+                epoch.to_string(),
+                master_accumulator.historical_epochs[epoch].0,
+            ) {
+                Ok(true) => {
+                    log::info!("Skipping, epoch already synced: {}", epoch);
+                    continue;
+                }
+                Ok(false) => {
+                    log::info!("syncing new epoch: {}", epoch);
+                }
+                Err(e) => {
+                    return {
+                        log::error!("error: {}", e);
+                        Err(EraValidateError::EpochAccumulatorError)
+                    }
                 }
             }
         }
-
-        let epoch_blocks: Vec<Block> = blocks.drain(0..MAX_EPOCH_SIZE).collect();
-        let root = process_blocks(epoch_blocks, epoch, &master_accumulator)?;
+        let epoch_headers: Vec<ExtHeaderRecord> = headers.drain(0..MAX_EPOCH_SIZE).collect();
+        let root = process_headers(epoch_headers, epoch, &master_accumulator)?;
         validated_epochs.push(epoch);
         // stores the validated epoch into lockfile to avoid validating again and keeping a concise state
-        match store_last_state(Path::new("./lockfile.json"), LockEntry::new(&epoch, root)) {
-            Ok(_) => {}
-            Err(e) => {
-                log::error!("error: {}", e);
-                return Err(EraValidateError::EpochAccumulatorError);
+        if use_lock {
+            match store_last_state(Path::new("./lockfile.json"), LockEntry::new(&epoch, root)) {
+                Ok(_) => {}
+                Err(e) => {
+                    log::error!("error: {}", e);
+                    return Err(EraValidateError::EpochAccumulatorError);
+                }
             }
         }
     }
@@ -97,21 +95,41 @@ pub fn era_validate(
     Ok(validated_epochs)
 }
 
-/// takes 8192 blocks and checks if they consist in a valid epoch
-fn process_blocks(
-    mut blocks: Vec<sf::ethereum::r#type::v2::Block>,
+/// takes 8192 block headers and checks if they consist in a valid epoch.
+///
+/// An epoch must respect the order of blocks, i.e., block numbers for epoch
+/// 0 must start from block 0 to block 8191.
+///
+/// headers can only be validated for now against epochs before The Merge.
+/// All pre-merge blocks (which are numbered before [`FINAL_EPOCH`]), are validated using
+/// the [Header Accumulator](https://github.com/ethereum/portal-network-specs/blob/8ad5bc33cb0d4485d2eab73bf2decc43e7566a8f/history-network.md#the-header-accumulator)
+///
+/// For block post merge, the sync-committee should be used to validate block headers   
+/// in the canonical blockchain. So this function is not useful for those.
+fn process_headers(
+    mut headers: Vec<ExtHeaderRecord>,
     epoch: usize,
     master_accumulator: &MasterAccumulator,
 ) -> Result<[u8; 32], EraValidateError> {
-    if blocks.len() != MAX_EPOCH_SIZE {
+    if headers.len() != MAX_EPOCH_SIZE {
         Err(EraValidateError::InvalidEpochLength)?;
+    }
+    if headers[0].block_number % MAX_EPOCH_SIZE as u64 != 0 {
+        Err(EraValidateError::InvalidEpochStart)?;
     }
 
     if epoch > FINAL_EPOCH {
-        blocks.retain(|block: &Block| block.number < MERGE_BLOCK);
+        log::warn!(
+            "the blocks from this epoch are not being validated since they are post merge.
+        For post merge blocks, use the sync-committee subprotocol"
+        );
+        headers.retain(|header: &ExtHeaderRecord| header.block_number < MERGE_BLOCK);
     }
 
-    let header_records = decode_header_records(blocks)?;
+    let header_records: Vec<HeaderRecord> = headers
+        .into_iter()
+        .map(|ext_record| HeaderRecord::from(ext_record))
+        .collect();
     let epoch_accumulator = compute_epoch_accumulator(&header_records)?;
 
     // Return an error if the epoch accumulator does not match the master accumulator
@@ -129,62 +147,97 @@ fn process_blocks(
     Ok(root)
 }
 
-pub fn stream_validation<R: Read + BufRead, W: StdWrite>(
-    master_accumulator: MasterAccumulator,
-    mut reader: R,
-    mut writer: W,
-) -> Result<(), EraValidateError> {
-    let mut header_records = Vec::new();
-    let mut append_flag = false;
-    let mut buf = String::new();
+// TODO: move stream validation to be a functionality of flat_head
+// pub fn stream_validation<R: Read + BufRead, W: StdWrite>(
+//     master_accumulator: MasterAccumulator,
+//     mut reader: R,
+//     mut writer: W,
+// ) -> Result<(), EraValidateError> {
+//     let mut header_records = Vec::new();
+//     let mut append_flag = false;
+//     let mut buf = String::new();
 
-    while let Ok(hrwn) = receive_message(&mut reader) {
-        buf.clear();
-        if header_records.len() == 0 {
-            if hrwn.block_number % MAX_EPOCH_SIZE as u64 == 0 {
-                let epoch = hrwn.block_number as usize / MAX_EPOCH_SIZE;
-                log::info!("Validating epoch: {}", epoch);
-                append_flag = true;
-            }
-        }
-        if append_flag == true {
-            let header_record = HeaderRecord {
-                block_hash: H256::from_slice(&hrwn.block_hash),
-                total_difficulty: U256::try_from(hrwn.total_difficulty.as_slice())
-                    .map_err(|_| EraValidateError::TotalDifficultyDecodeError)?,
-            };
-            header_records.push(header_record);
-        }
+//     while let Ok(hrwn) = receive_message(&mut reader) {
+//         buf.clear();
 
-        if header_records.len() == MAX_EPOCH_SIZE {
-            let epoch = hrwn.block_number as usize / MAX_EPOCH_SIZE;
-            let epoch_accumulator = compute_epoch_accumulator(&header_records)?;
-            if epoch_accumulator.tree_hash_root().0 != master_accumulator.historical_epochs[epoch].0
-            {
-                Err(EraValidateError::EraAccumulatorMismatch)?;
-            }
-            log::info!("Validated epoch: {}", epoch);
-            writer
-                .write_all(format!("Validated epoch: {}\n", epoch).as_bytes())
-                .map_err(|_| EraValidateError::JsonError)?;
-            header_records.clear();
-        }
-    }
-    log::info!("Read {} block headers from stdin", header_records.len());
-    Ok(())
-}
+//         log::info!("{:?}", hrwn.block_hash);
+//         if header_records.len() == 0 {
+//             if hrwn.block_number % MAX_EPOCH_SIZE as u64 == 0 {
+//                 let epoch = hrwn.block_number as usize / MAX_EPOCH_SIZE;
+//                 log::info!("Validating epoch: {}", epoch);
+//                 append_flag = true;
+//             }
+//         }
+//         if append_flag == true {
+//             let header_record = HeaderRecord {
+//                 block_hash: H256::from_slice(&hrwn.block_hash),
+//                 total_difficulty: U256::try_from(hrwn.total_difficulty.as_slice())
+//                     .map_err(|_| EraValidateError::TotalDifficultyDecodeError)?,
+//             };
+//             header_records.push(header_record);
+//         }
 
-fn receive_message<R: Read>(reader: &mut R) -> Result<HeaderRecordWithNumber, bincode::Error> {
-    let mut size_buf = [0u8; 4];
-    if reader.read_exact(&mut size_buf).is_err() {
-        return Err(Box::new(bincode::ErrorKind::Io(std::io::Error::new(
-            std::io::ErrorKind::UnexpectedEof,
-            "Failed to read size",
-        ))));
-    }
-    let size = u32::from_be_bytes(size_buf) as usize;
+//         if header_records.len() == MAX_EPOCH_SIZE {
+//             let epoch = hrwn.block_number as usize / MAX_EPOCH_SIZE;
+//             let epoch_accumulator = compute_epoch_accumulator(&header_records)?;
+//             if epoch_accumulator.tree_hash_root().0 != master_accumulator.historical_epochs[epoch].0
+//             {
+//                 Err(EraValidateError::EraAccumulatorMismatch)?;
+//             }
+//             log::info!("Validated epoch: {}", epoch);
+//             writer
+//                 .write_all(format!("Validated epoch: {}\n", epoch).as_bytes())
+//                 .map_err(|_| EraValidateError::JsonError)?;
+//             header_records.clear();
+//         }
+//     }
 
-    let mut buf = vec![0u8; size];
-    reader.read_exact(&mut buf)?;
-    bincode::deserialize(&buf)
-}
+//     log::info!("Read {} block headers from stdin", header_records.len());
+//     Ok(())
+// }
+
+// TODO: this functionality should be moved to flat_head
+// fn receive_message<R: Read>(reader: &mut R) -> Result<HeaderRecordWithNumber, Box<dyn Error>> {
+//     let mut size_buf = [0u8; 4];
+//     if reader.read_exact(&mut size_buf).is_err() {
+//         return Err(Box::new(bincode::ErrorKind::Io(std::io::Error::new(
+//             std::io::ErrorKind::UnexpectedEof,
+//             "Failed to read size",
+//         ))));
+//     }
+
+//     let size = u32::from_be_bytes(size_buf) as usize;
+//     println!("size: {:?}", size);
+
+//     let mut buf = vec![0u8; size];
+//     reader.read_exact(&mut buf)?;
+//     let hrwn: HeaderRecordWithNumber = bincode::deserialize(&buf)?;
+
+//     println!(" decoding {:?}", hrwn);
+//     Ok(hrwn)
+// }
+
+// Test function
+
+//  TODO: move this test to flat_head
+// #[cfg(test)]
+// mod tests {
+//     use std::{fs::File, io, path::PathBuf};
+
+//     use super::*;
+
+//     #[test]
+//     fn test_receive_message_from_file() -> Result<(), Box<dyn Error>> {
+//         let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+//         path.push("tests/ethereum_firehose_first_8200/0000000000.dbin"); // Adjust the path as needed
+
+//         let file = File::open(path)?;
+//         let mut reader = io::BufReader::new(file);
+
+//         let result = receive_message(&mut reader)?;
+
+//         println!("block: {:?}", result.block_hash);
+
+//         Ok(())
+//     }
+// }

--- a/src/era_validator.rs
+++ b/src/era_validator.rs
@@ -59,7 +59,7 @@ pub fn era_validate(
     }
 
     let mut validated_epochs = Vec::new();
-    for epoch in start_epoch..=end_epoch {
+    for epoch in start_epoch..end_epoch {
         // checks if epoch was already synced form lockfile.
         match check_sync_state(
             Path::new("./lockfile.json"),

--- a/src/era_validator.rs
+++ b/src/era_validator.rs
@@ -72,7 +72,9 @@ pub fn era_validate(
             Ok(false) => {
                 log::info!("syncing new epoch: {}", epoch);
             }
-            Err(_) => return Err(EraValidateError::EpochAccumulatorError),
+            Err(e) => return {
+                log::error!("error: {}", e);
+                Err(EraValidateError::EpochAccumulatorError)},
         }
 
         let epoch_blocks: Vec<Block> = blocks.drain(0..MAX_EPOCH_SIZE).collect();

--- a/src/era_validator.rs
+++ b/src/era_validator.rs
@@ -83,7 +83,9 @@ pub fn era_validate(
         // stores the validated epoch into lockfile to avoid validating again and keeping a concise state
         match store_last_state(Path::new("./lockfile.json"), LockEntry::new(&epoch, root)) {
             Ok(_) => {}
-            Err(_) => return Err(EraValidateError::EpochAccumulatorError),
+            Err(e) =>{ 
+                log::error!("error: {}", e);
+                return Err(EraValidateError::EpochAccumulatorError)},
         }
     }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -15,6 +15,7 @@ pub enum EraValidateError {
     MergeBlockNotFound,
     JsonError,
     TotalDifficultyDecodeError,
+    InvalidEpochLength,
 }
 #[derive(Debug)]
 pub enum SyncError {
@@ -57,6 +58,9 @@ impl fmt::Display for EraValidateError {
             }
             EraValidateError::TotalDifficultyDecodeError => {
                 write!(f, "Error decoding total difficulty")
+            }
+            EraValidateError::InvalidEpochLength => {
+                write!(f, "blocks in epoch must be exactly 8192 units")
             }
         }
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -9,12 +9,14 @@ pub enum EraValidateError {
     EraAccumulatorMismatch,
     EpochAccumulatorError,
     ProofGenerationFailure,
+    ProofValidationFailure,
     IoError,
     StartEpochBlockNotFound,
     EndEpochLessThanStartEpoch,
     MergeBlockNotFound,
     JsonError,
     TotalDifficultyDecodeError,
+    InvalidEpochStart,
     InvalidEpochLength,
 }
 #[derive(Debug)]
@@ -43,6 +45,9 @@ impl fmt::Display for EraValidateError {
             EraValidateError::ProofGenerationFailure => {
                 write!(f, "Error generating inclusion proof")
             }
+            EraValidateError::ProofValidationFailure => {
+                write!(f, "Error validating inclusion proof")
+            }
             EraValidateError::IoError => write!(f, "Error reading from stdin"),
             EraValidateError::StartEpochBlockNotFound => {
                 write!(f, "Start epoch block not found")
@@ -61,6 +66,12 @@ impl fmt::Display for EraValidateError {
             }
             EraValidateError::InvalidEpochLength => {
                 write!(f, "blocks in epoch must be exactly 8192 units")
+            }
+            EraValidateError::InvalidEpochStart => {
+                write!(
+                    f,
+                    "blocks in epoch must respect the range of blocks numbers"
+                )
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,4 +2,5 @@ pub mod era_validator;
 pub mod errors;
 pub mod inclusion_proof;
 pub mod sync;
+pub mod types;
 pub mod utils;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,5 @@
 use clap::{Arg, Command, Parser, Subcommand};
-use header_accumulator::{
-    era_validator::stream_validation, errors::EraValidateError, inclusion_proof,
-};
-use primitive_types::H256;
+use header_accumulator::errors::EraValidateError;
 use std::{io::BufReader, process};
 use trin_validation::accumulator::MasterAccumulator;
 
@@ -154,82 +151,83 @@ fn main() {
                 };
                 let reader = BufReader::with_capacity(1 << 32, std::io::stdin().lock());
                 let writer = std::io::stdout();
-                stream_validation(master_accumulator.clone(), reader, writer)
-                    .expect("Validation Error");
+                // stream_validation(master_accumulator.clone(), reader, writer)
+                //     .expect("Validation Error");
                 process::exit(0);
             }
             _ => {}
         },
-        Some(("generate_inclusion_proof", generate_inclusion_proof_matches)) => {
-            let directory = generate_inclusion_proof_matches
-                .get_one::<String>("directory")
-                .expect("Directory is required.");
-            let start_block = generate_inclusion_proof_matches
-                .get_one::<String>("start_block")
-                .expect("Start block is required.");
-            let end_block = generate_inclusion_proof_matches
-                .get_one::<String>("end_block")
-                .expect("End block is required.");
+        //TODO: move this functionality to flat_head
+        // Some(("generate_inclusion_proof", generate_inclusion_proof_matches)) => {
+        //     let directory = generate_inclusion_proof_matches
+        //         .get_one::<String>("directory")
+        //         .expect("Directory is required.");
+        //     let start_block = generate_inclusion_proof_matches
+        //         .get_one::<String>("start_block")
+        //         .expect("Start block is required.");
+        //     let end_block = generate_inclusion_proof_matches
+        //         .get_one::<String>("end_block")
+        //         .expect("End block is required.");
 
-            let inclusion_proof = inclusion_proof::generate_inclusion_proof(
-                &directory,
-                start_block.parse::<usize>().unwrap(),
-                end_block.parse::<usize>().unwrap(),
-            )
-            .expect("Error generating inclusion proof");
+        //     let inclusion_proof = inclusion_proof::generate_inclusion_proof(
+        //         &directory,
+        //         start_block.parse::<usize>().unwrap(),
+        //         end_block.parse::<usize>().unwrap(),
+        //     )
+        //     .expect("Error generating inclusion proof");
 
-            let inclusion_proof_serialized = serde_json::to_string(&inclusion_proof).unwrap();
-            // write the proof to a file
-            // if output_file is not provided, write to inclusion_proof.json
-            let output_file = generate_inclusion_proof_matches.get_one::<String>("output_file");
-            match output_file {
-                Some(output_file) => {
-                    std::fs::write(output_file.to_owned() + ".json", inclusion_proof_serialized)
-                        .expect("Unable to write file");
-                }
-                None => {
-                    std::fs::write("inclusion_proof.json", inclusion_proof_serialized)
-                        .expect("Unable to write file");
-                }
-            }
-            process::exit(0);
-        }
-        Some(("verify_inclusion_proof", verify_inclusion_proof_matches)) => {
-            let directory = verify_inclusion_proof_matches
-                .get_one::<String>("directory")
-                .expect("Directory is required.");
-            let start_block = verify_inclusion_proof_matches
-                .get_one::<String>("start_block")
-                .expect("Start block is required.");
-            let end_block = verify_inclusion_proof_matches
-                .get_one::<String>("end_block")
-                .expect("End block is required.");
-            let inclusion_proof_file = verify_inclusion_proof_matches
-                .get_one::<String>("inclusion_proof_file")
-                .expect("Inclusion proof is required.");
+        //     let inclusion_proof_serialized = serde_json::to_string(&inclusion_proof).unwrap();
+        //     // write the proof to a file
+        //     // if output_file is not provided, write to inclusion_proof.json
+        //     let output_file = generate_inclusion_proof_matches.get_one::<String>("output_file");
+        //     match output_file {
+        //         Some(output_file) => {
+        //             std::fs::write(output_file.to_owned() + ".json", inclusion_proof_serialized)
+        //                 .expect("Unable to write file");
+        //         }
+        //         None => {
+        //             std::fs::write("inclusion_proof.json", inclusion_proof_serialized)
+        //                 .expect("Unable to write file");
+        //         }
+        //     }
+        //     process::exit(0);
+        // }
+        // Some(("verify_inclusion_proof", verify_inclusion_proof_matches)) => {
+        //     let directory = verify_inclusion_proof_matches
+        //         .get_one::<String>("directory")
+        //         .expect("Directory is required.");
+        //     let start_block = verify_inclusion_proof_matches
+        //         .get_one::<String>("start_block")
+        //         .expect("Start block is required.");
+        //     let end_block = verify_inclusion_proof_matches
+        //         .get_one::<String>("end_block")
+        //         .expect("End block is required.");
+        //     let inclusion_proof_file = verify_inclusion_proof_matches
+        //         .get_one::<String>("inclusion_proof_file")
+        //         .expect("Inclusion proof is required.");
 
-            // Load inclusion proof
-            let inclusion_proof = std::fs::read_to_string(inclusion_proof_file)
-                .expect("Error reading inclusion proof file");
-            let inclusion_proof: Vec<[H256; 15]> =
-                serde_json::from_str(&inclusion_proof).expect("Error parsing inclusion proof");
+        //     // Load inclusion proof
+        //     let inclusion_proof = std::fs::read_to_string(inclusion_proof_file)
+        //         .expect("Error reading inclusion proof file");
+        //     let inclusion_proof: Vec<[H256; 15]> =
+        //         serde_json::from_str(&inclusion_proof).expect("Error parsing inclusion proof");
 
-            let result = inclusion_proof::verify_inclusion_proof(
-                &directory,
-                None,
-                start_block.parse::<usize>().unwrap(),
-                end_block.parse::<usize>().unwrap(),
-                inclusion_proof,
-            );
+        //     let result = inclusion_proof::verify_inclusion_proof(
+        //         &directory,
+        //         None,
+        //         start_block.parse::<usize>().unwrap(),
+        //         end_block.parse::<usize>().unwrap(),
+        //         inclusion_proof,
+        //     );
 
-            if result.is_ok() {
-                println!("Inclusion proof verified!");
-                process::exit(0);
-            } else {
-                println!("Inclusion proof failed to verify");
-                process::exit(1);
-            }
-        }
+        //     if result.is_ok() {
+        //         println!("Inclusion proof verified!");
+        //         process::exit(0);
+        //     } else {
+        //         println!("Inclusion proof failed to verify");
+        //         process::exit(1);
+        //     }
+        // }
         _ => {
             println!("No subcommand was used");
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -137,6 +137,7 @@ fn main() {
         .get_matches();
 
     match matches.subcommand() {
+        // TODO: move this functionality to flat_head
         Some(("era_validate", era_validate_matches)) => match era_validate_matches.subcommand() {
             Some(("stream", stream_matches)) => {
                 let master_accumulator_file =

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,8 +30,6 @@ enum Commands {
         input: String,
         #[clap(long)]
         headers_dir: Option<String>,
-        #[clap(short, long)]
-        output: Option<String>,
     },
 }
 

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -107,6 +107,11 @@ pub fn check_sync_state(
     };
 
     if macc_hash != stored_hash {
+        log::error!(
+            "the valid hash is: {:?} and the provided hash was: {:?}",
+            macc_hash,
+            stored_hash
+        );
         return Err(Box::new(EraValidateError::EraAccumulatorMismatch));
     }
 

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -8,7 +8,6 @@ use std::path::Path;
 
 use crate::errors::{EraValidateError, SyncError};
 
-#[derive(Serialize, Deserialize)]
 pub struct LockEntry {
     epoch: String,
     root: String,
@@ -20,10 +19,6 @@ impl LockEntry {
             epoch: epoch.to_string(),
             root: BASE64_STANDARD.encode(root),
         }
-    }
-
-    pub fn hash(&self) -> String {
-        self.root.clone()
     }
 }
 
@@ -105,11 +100,6 @@ pub fn check_sync_state(
         Ok(b) => b,
         Err(_) => panic!("Decoded hash does not fit into a 32-byte array"),
     };
-
-    println!(
-        "stored hash: {:?}, ac hash: {:?}",
-        stored_hash[0], macc_hash[0]
-    );
 
     if macc_hash != stored_hash {
         log::error!(

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,5 +1,4 @@
 use base64::prelude::*;
-use revm_primitives::bitvec::access;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::error::Error;

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -93,7 +93,7 @@ pub fn check_sync_state(
 
     let stored_hash = json_lock
         .entries
-        .get("0")
+        .get(&epoch)
         .ok_or(SyncError::LockfileReadError)?;
 
     let stored_hash = BASE64_STANDARD

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,0 +1,65 @@
+use ethereum_types::H256 as Hash256;
+use ethereum_types::U256 as EthereumU256;
+use ethereum_types::{H256, U256};
+use ethportal_api::{types::execution::accumulator::HeaderRecord, Header};
+use sf_protos::ethereum::r#type::v2::Block;
+
+use crate::errors::EraValidateError;
+use crate::utils::header_from_block;
+
+#[derive(Clone)]
+pub struct ExtHeaderRecord {
+    pub block_hash: H256,
+    pub total_difficulty: U256,
+    pub block_number: u64,
+    pub full_header: Option<Header>,
+}
+
+impl From<ExtHeaderRecord> for HeaderRecord {
+    fn from(ext: ExtHeaderRecord) -> Self {
+        HeaderRecord {
+            block_hash: ext.block_hash,
+            total_difficulty: ext.total_difficulty,
+        }
+    }
+}
+
+impl From<ExtHeaderRecord> for Header {
+    fn from(ext: ExtHeaderRecord) -> Self {
+        ext.full_header.unwrap()
+    }
+}
+
+impl From<&ExtHeaderRecord> for HeaderRecord {
+    fn from(ext: &ExtHeaderRecord) -> Self {
+        HeaderRecord {
+            block_hash: ext.block_hash,
+            total_difficulty: ext.total_difficulty,
+        }
+    }
+}
+
+/// Decodes a [`ExtHeaderRecord`] from a [`Block`]. A [`BlockHeader`] must be present in the block,
+/// otherwise validating headers won't be possible
+impl TryFrom<&Block> for ExtHeaderRecord {
+    type Error = EraValidateError; // Ensure this matches your error type
+
+    fn try_from(block: &Block) -> Result<Self, Self::Error> {
+        let header = block
+            .header
+            .as_ref()
+            .ok_or(EraValidateError::HeaderDecodeError)?;
+        let total_difficulty = header
+            .total_difficulty
+            .as_ref()
+            .ok_or(EraValidateError::HeaderDecodeError)?;
+
+        Ok(ExtHeaderRecord {
+            block_number: block.number,
+            block_hash: Hash256::from_slice(&block.hash),
+            total_difficulty: EthereumU256::try_from(total_difficulty.bytes.as_slice())
+                .map_err(|_| EraValidateError::HeaderDecodeError)?,
+            full_header: Some(header_from_block(&block)?), // Assuming header_from_block returns Result<_, EraValidateError>
+        })
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -9,7 +9,7 @@ use crate::errors::EraValidateError;
 
 pub const MAX_EPOCH_SIZE: usize = 8192;
 pub const FINAL_EPOCH: usize = 01896;
-pub const MERGE_BLOCK: usize = 15537394;
+pub const MERGE_BLOCK: u64 = 15537394;
 
 // TODO: move this function to flat_head
 pub fn extract_100_blocks(

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -11,6 +11,7 @@ pub const MAX_EPOCH_SIZE: usize = 8192;
 pub const FINAL_EPOCH: usize = 01896;
 pub const MERGE_BLOCK: usize = 15537394;
 
+// TODO: move this function to flat_head
 pub fn extract_100_blocks(
     directory: &String,
     start_block: usize,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,85 +1,14 @@
-use decoder::decode_flat_files;
-use decoder::sf::ethereum::r#type::v2::{Block, BlockHeader};
 use ethereum_types::H256 as Hash256;
 use ethereum_types::{Bloom, H160, H64, U256 as EthereumU256};
 use ethportal_api::types::execution::accumulator::{EpochAccumulator, HeaderRecord};
 use ethportal_api::Header;
+use sf_protos::ethereum::r#type::v2::Block;
 
 use crate::errors::EraValidateError;
 
 pub const MAX_EPOCH_SIZE: usize = 8192;
 pub const FINAL_EPOCH: usize = 01896;
 pub const MERGE_BLOCK: u64 = 15537394;
-
-// TODO: move this function to flat_head
-pub fn extract_100_blocks(
-    directory: &String,
-    start_block: usize,
-    end_block: usize,
-) -> Result<Vec<Block>, EraValidateError> {
-    // Flat files are stored in 100 block files
-    // So we need to find the 100 block file that contains the start block and the 100 block file that contains the end block
-    let start_100_block = (start_block / 100) * 100;
-    let end_100_block = (((end_block as f32) / 100.0).ceil() as usize) * 100;
-
-    let mut blocks: Vec<Block> = Vec::new();
-    for block_number in (start_100_block..end_100_block).step_by(100) {
-        let block_file_name = directory.to_owned() + &format!("/{:010}.dbin", block_number);
-        let block = &decode_flat_files(block_file_name, None, None)
-            .map_err(|_| EraValidateError::FlatFileDecodeError)?;
-        blocks.extend(block.clone());
-    }
-
-    // Return only the requested blocks
-    Ok(blocks[start_block - start_100_block..end_block - start_100_block].to_vec())
-}
-
-pub fn decode_header_records(blocks: Vec<Block>) -> Result<Vec<HeaderRecord>, EraValidateError> {
-    let mut header_records = Vec::<HeaderRecord>::new();
-    for block in blocks {
-        let header_record = HeaderRecord {
-            block_hash: Hash256::from_slice(block.hash.as_slice()),
-            total_difficulty: EthereumU256::try_from(
-                block
-                    .header
-                    .ok_or(EraValidateError::HeaderDecodeError)?
-                    .total_difficulty
-                    .as_ref()
-                    .ok_or(EraValidateError::HeaderDecodeError)?
-                    .bytes
-                    .as_slice(),
-            )
-            .map_err(|_| EraValidateError::HeaderDecodeError)?,
-        };
-        header_records.push(header_record);
-    }
-
-    Ok(header_records)
-}
-
-pub fn decode_header_records_from_header(
-    block_headers: &Vec<BlockHeader>,
-) -> Result<Vec<HeaderRecord>, EraValidateError> {
-    let _ = block_headers;
-    let mut header_records = Vec::<HeaderRecord>::new();
-    for block in block_headers {
-        let header_record = HeaderRecord {
-            block_hash: Hash256::from_slice(block.hash.as_slice()),
-            total_difficulty: EthereumU256::try_from(
-                block
-                    .total_difficulty
-                    .as_ref()
-                    .ok_or(EraValidateError::HeaderDecodeError)?
-                    .bytes
-                    .as_slice(),
-            )
-            .map_err(|_| EraValidateError::HeaderDecodeError)?,
-        };
-        header_records.push(header_record);
-    }
-
-    Ok(header_records)
-}
 
 pub fn compute_epoch_accumulator(
     header_records: &Vec<HeaderRecord>,
@@ -96,8 +25,11 @@ pub fn compute_epoch_accumulator(
     Ok(epoch_accumulator)
 }
 
-pub fn header_from_block(block: Block) -> Result<Header, EraValidateError> {
-    let block_header = block.header.ok_or(EraValidateError::HeaderDecodeError)?;
+pub fn header_from_block(block: &Block) -> Result<Header, EraValidateError> {
+    let block_header = block
+        .header
+        .as_ref()
+        .ok_or(EraValidateError::HeaderDecodeError)?;
     let parent_hash = Hash256::from_slice(block_header.parent_hash.as_slice());
     let uncles_hash = Hash256::from_slice(block_header.uncle_hash.as_slice());
     let author = H160::from_slice(block_header.coinbase.as_slice());

--- a/tests/era_validator.rs
+++ b/tests/era_validator.rs
@@ -1,0 +1,70 @@
+use std::fs;
+
+use decoder::decode_flat_files;
+use header_accumulator::{
+    era_validator::era_validate, errors::EraValidateError, types::ExtHeaderRecord,
+};
+
+#[test]
+fn test_era_validate() -> Result<(), EraValidateError> {
+    // clean up before tests
+    if let Err(e) = fs::remove_file("lockfile.json") {
+        eprintln!("Error deleting lockfile.json: {}", e);
+    }
+
+    let mut headers: Vec<ExtHeaderRecord> = Vec::new();
+    for number in (0..=8200).step_by(100) {
+        let file_name = format!("tests/ethereum_firehose_first_8200/{:010}.dbin", number);
+        match decode_flat_files(file_name, None, None) {
+            Ok(blocks) => {
+                let (successful_headers, _): (Vec<_>, Vec<_>) = blocks
+                    .iter()
+                    .cloned()
+                    .map(|block| ExtHeaderRecord::try_from(&block))
+                    .fold((Vec::new(), Vec::new()), |(mut succ, mut errs), res| {
+                        match res {
+                            Ok(header) => succ.push(header),
+                            Err(e) => {
+                                // Log the error or handle it as needed
+                                eprintln!("Error converting block: {:?}", e);
+                                errs.push(e);
+                            }
+                        };
+                        (succ, errs)
+                    });
+
+                headers.extend(successful_headers);
+            }
+            Err(e) => {
+                eprintln!("error: {:?}", e);
+                break;
+            }
+        }
+    }
+    assert_eq!(headers.len(), 8300);
+    assert_eq!(headers[0].block_number, 0);
+
+    let result = era_validate(headers.clone(), None, 0, None, Some(false))?;
+    println!("result 1: {:?}", result);
+
+    assert!(result.contains(&0), "The vector does not contain 0");
+
+    // Test with creating a lockfile
+    let result = era_validate(headers.clone(), None, 0, None, Some(true))?;
+    println!("result 2: {:?}", result);
+
+    assert!(result.contains(&0), "The vector does not contain 0");
+
+    // test with the lockfile created before.
+    let result = era_validate(headers.clone(), None, 0, None, Some(true))?;
+
+    // already validated epochs are not included in the array.
+    assert_eq!(result.len(), 0);
+
+    // clean up after tests
+    if let Err(e) = fs::remove_file("lockfile.json") {
+        eprintln!("Error deleting lockfile.json: {}", e);
+    }
+
+    Ok(())
+}

--- a/tests/inclusion_proof.rs
+++ b/tests/inclusion_proof.rs
@@ -1,23 +1,59 @@
+use decoder::decode_flat_files;
 use header_accumulator::{
     self,
+    errors::EraValidateError,
     inclusion_proof::{generate_inclusion_proof, verify_inclusion_proof},
+    types::ExtHeaderRecord,
 };
+use sf_protos::ethereum::r#type::v2::Block;
 
 #[test]
-fn test_inclusion_proof() {
-    let directory = String::from("tests/ethereum_firehose_first_8200");
+fn test_inclusion_proof() -> Result<(), EraValidateError> {
+    let mut headers: Vec<ExtHeaderRecord> = Vec::new();
+    let mut all_blocks: Vec<Block> = Vec::new(); // Vector to hold all blocks
+
+    for flat_file_number in (0..=8200).step_by(100) {
+        let file_name = format!(
+            "tests/ethereum_firehose_first_8200/{:010}.dbin",
+            flat_file_number
+        );
+        match decode_flat_files(file_name, None, None) {
+            Ok(blocks) => {
+                headers.extend(
+                    blocks
+                        .iter()
+                        .map(|block| ExtHeaderRecord::try_from(block).unwrap())
+                        .collect::<Vec<ExtHeaderRecord>>(),
+                );
+                all_blocks.extend(blocks); // Extend the all_blocks vector with the decoded blocks
+            }
+            Err(e) => {
+                eprintln!("error: {:?}", e);
+                break;
+            }
+        }
+    }
+
     let start_block = 301;
     let end_block = 402;
-    let inclusion_proof = generate_inclusion_proof(&directory, start_block, end_block)
-        .unwrap_or_else(|e| {
+    let inclusion_proof =
+        generate_inclusion_proof(headers, start_block, end_block).unwrap_or_else(|e| {
             println!("Error occurred: {}", e);
             // Handle the error, e.g., by exiting the program or returning a default value
             std::process::exit(1); // Exiting the program, for example
         });
-    assert_eq!(inclusion_proof.len(), end_block - start_block);
+    assert_eq!(
+        inclusion_proof.len() as usize,
+        (end_block - start_block + 1) as usize
+    );
 
     // Verify inclusion proof
-    assert!(
-        verify_inclusion_proof(&directory, None, start_block, end_block, inclusion_proof).is_ok()
-    );
+    let proof_blocks: Vec<Block> = all_blocks[start_block as usize..=end_block as usize].to_vec();
+    assert!(verify_inclusion_proof(proof_blocks, None, inclusion_proof.clone()).is_ok());
+
+    // verify if inclusion proof fails on not proven blocks
+    let proof_blocks: Vec<Block> = all_blocks[302..=403].to_vec();
+    assert!(verify_inclusion_proof(proof_blocks, None, inclusion_proof.clone()).is_err());
+
+    Ok(())
 }

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -10,6 +10,6 @@ fn test_header_from_block() {
     )
     .unwrap();
 
-    let header = header_from_block(blocks[0].clone()).unwrap();
+    let header = header_from_block(&blocks[0].clone()).unwrap();
     assert_eq!(header.hash().as_bytes(), blocks[0].hash)
 }


### PR DESCRIPTION
The intention here is to move what comes from flat_files_decoder outside of header_accumulator and use it together in [flat_head](https://github.com/semiotic-ai/flat_head).

header_accumulator will no longer have the functionality of `era_validate`, as this uses flat_files_decoder function `decode_flat_files`. Instead, this functionality is simplified by using the `Block` structure. The same functionality, however, is now part of flat_head. And now, it is possible to make a single executable separating the responsibilities of each crate.


@severiano-sisneros, please check the changes, this is just the gist of it, but since it requires me to move between repos I'm asking for validation first.  There is some code to be deleted still. A piece of code at `main.rs` was left in order to understand and test what were the steps necessary in flat_head. These will be removed before this PR.