### PR TITLE
ci: use protoc v3 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         run: cargo fmt -- --check
 
       - name: Install Protoc
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+        uses: arduino/setup-protoc@v3
 
       - name: Install Clippy
         run: rustup component add clippy


### PR DESCRIPTION
## [TRU-270](https://linear.app/semiotic/issue/TRU-270/update-protobuf-compiler-in-ci)